### PR TITLE
Refactor Dockerfile

### DIFF
--- a/backend-node/backend-node.dockerfile
+++ b/backend-node/backend-node.dockerfile
@@ -296,17 +296,12 @@ touch /etc/s6-overlay/s6-rc.d/user/contents.d/advancer
 echo "longrun" > /etc/s6-overlay/s6-rc.d/advancer/type
 EOF
 
-COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/advancer/start.sh
-#!/command/with-contenv sh
-cartesi-rollups-advancer
-EOF
-
 COPY <<EOF /etc/s6-overlay/s6-rc.d/advancer/run
 #!/command/execlineb -P
 with-contenv
 pipeline -w { sed --unbuffered "s/^/advancer: /" }
 fdmove -c 2 1
-/bin/sh /etc/s6-overlay/s6-rc.d/advancer/start.sh
+cartesi-rollups-advancer
 EOF
 
 ################################################################################
@@ -318,17 +313,12 @@ touch /etc/s6-overlay/s6-rc.d/user/contents.d/validator
 echo "longrun" > /etc/s6-overlay/s6-rc.d/validator/type
 EOF
 
-COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/validator/start.sh
-#!/command/with-contenv sh
-cartesi-rollups-validator
-EOF
-
 COPY <<EOF /etc/s6-overlay/s6-rc.d/validator/run
 #!/command/execlineb -P
 with-contenv
 pipeline -w { sed --unbuffered "s/^/validator: /" }
 fdmove -c 2 1
-/bin/sh /etc/s6-overlay/s6-rc.d/validator/start.sh
+cartesi-rollups-validator
 EOF
 
 ################################################################################
@@ -339,17 +329,12 @@ touch /etc/s6-overlay/s6-rc.d/claimer/dependencies.d/{prepare-dirs, migrate}
 echo "longrun" > /etc/s6-overlay/s6-rc.d/claimer/type
 EOF
 
-COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/claimer/start.sh
-#!/command/with-contenv sh
-cartesi-rollups-claimer
-EOF
-
 COPY <<EOF /etc/s6-overlay/s6-rc.d/claimer/run
 #!/command/execlineb -P
 with-contenv
 pipeline -w { sed --unbuffered "s/^/claimer: /" }
 fdmove -c 2 1
-/bin/sh /etc/s6-overlay/s6-rc.d/claimer/start.sh
+cartesi-rollups-claimer
 EOF
 
 ################################################################################
@@ -380,9 +365,13 @@ touch /etc/s6-overlay/s6-rc.d/user/contents.d/hlgraphql
 echo "longrun" > /etc/s6-overlay/s6-rc.d/hlgraphql/type
 EOF
 
-COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/hlgraphql/start.sh
-#!/command/with-contenv sh
-POSTGRES_DB=${GRAPHQL_DB} cartesi-rollups-hl-graphql \
+COPY <<EOF /etc/s6-overlay/s6-rc.d/hlgraphql/run
+#!/command/execlineb -P
+with-contenv
+pipeline -w { sed --unbuffered "s/^/hlgraphql: /" }
+fdmove -c 2 1
+importas POSTGRES_DB GRAPHQL_DB
+cartesi-rollups-hl-graphql \
     --disable-devnet \
     --disable-advance \
     --disable-inspect \
@@ -392,14 +381,6 @@ POSTGRES_DB=${GRAPHQL_DB} cartesi-rollups-hl-graphql \
     --graphile-disable-sync \
     --db-implementation=postgres \
     --db-raw-url=${CARTESI_POSTGRES_ENDPOINT}
-EOF
-
-COPY <<EOF /etc/s6-overlay/s6-rc.d/hlgraphql/run
-#!/command/execlineb -P
-with-contenv
-pipeline -w { sed --unbuffered "s/^/hlgraphql: /" }
-fdmove -c 2 1
-/bin/sh /etc/s6-overlay/s6-rc.d/hlgraphql/start.sh
 EOF
 
 # deploy script

--- a/backend-node/backend-node.dockerfile
+++ b/backend-node/backend-node.dockerfile
@@ -60,9 +60,9 @@ COPY --from=go-builder ${GO_BUILD_PATH}/rollups-node/cartesi-rollups-* /usr/bin
 # install s6 overlay
 ARG S6_OVERLAY_VERSION
 RUN curl -s -L https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz | \
-    tar xJf - -C / 
+    tar xJf - -C /
 RUN curl -s -L https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-$(uname -m).tar.xz | \
-    tar xJf - -C / 
+    tar xJf - -C /
 
 # install telegraf
 ARG TELEGRAF_VERSION
@@ -79,10 +79,10 @@ mkdir -p /etc/s6-overlay/s6-rc.d/user/contents.d
 chown -R cartesi:cartesi /etc/s6-overlay/s6-rc.d/user/contents.d
 EOF
 
+################################################################################
 # configure telegraf
-RUN <<EOF
-mkdir -p /etc/telegraf
-echo "
+RUN mkdir -p /etc/telegraf
+COPY <<EOF /etc/telegraf/telegraf.conf
 [agent]
     interval = '60s'
     round_interval = true
@@ -108,24 +108,27 @@ echo "
 [[outputs.prometheus_client]]
     listen = ':9000'
     collectors_exclude = ['process']
-" > /etc/telegraf/telegraf.conf
 EOF
 
 # Configure s6 Telegraf
 RUN <<EOF
-mkdir -p /etc/s6-overlay/s6-rc.d/telegraf
-echo "longrun" > /etc/s6-overlay/s6-rc.d/telegraf/type
 mkdir -p /etc/s6-overlay/s6-rc.d/telegraf/data
-echo "#!/command/execlineb -P
-wget -qO /dev/null 127.0.0.1:9274/
-" > /etc/s6-overlay/s6-rc.d/telegraf/data/check
-echo "#!/command/execlineb -P
-pipeline -w { sed --unbuffered \"s/^/telegraf: /\" }
-fdmove -c 2 1
-/usr/bin/telegraf
-" > /etc/s6-overlay/s6-rc.d/telegraf/run
+echo "longrun" > /etc/s6-overlay/s6-rc.d/telegraf/type
 EOF
 
+COPY <<EOF /etc/s6-overlay/s6-rc.d/telegraf/data/check
+#!/command/execlineb -P
+wget -qO /dev/null 127.0.0.1:9274/
+EOF
+
+COPY <<EOF /etc/s6-overlay/s6-rc.d/telegraf/run
+#!/command/execlineb -P
+pipeline -w { sed --unbuffered "s/^/telegraf: /" }
+fdmove -c 2 1
+/usr/bin/telegraf
+EOF
+
+################################################################################
 # Configure nginx
 RUN <<EOF
 mkdir -p /var/log/nginx/
@@ -133,7 +136,9 @@ chown -R cartesi:cartesi /var/log/nginx/
 mkdir -p /var/cache
 chown -R cartesi:cartesi /var/cache
 chown -R cartesi:cartesi /var/lib/nginx
-echo "
+EOF
+
+COPY <<EOF /etc/nginx/nginx.conf
 user cartesi;
 worker_processes  auto;
 
@@ -148,10 +153,10 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    log_format  main  '$remote_addr - $upstream_cache_status rt=$request_time [$time_local] \"$request\" '
-                      '$status $body_bytes_sent \"$http_referer\" '
-                      '\"$http_user_agent\" \"$http_x_forwarded_for\" '
-                      'uct=\"$upstream_connect_time\" uht=\"$upstream_header_time\" urt=\"$upstream_response_time\"';
+    log_format  main  '$remote_addr - $upstream_cache_status rt=$request_time [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      'uct="$upstream_connect_time" uht="$upstream_header_time" urt="$upstream_response_time"';
 
     access_log  /var/log/nginx/access.log  main;
 
@@ -162,7 +167,7 @@ http {
 
     #gzip  on;
 
-    map \$request_method \$purge_method {
+    map $request_method $purge_method {
         PURGE 1;
         default 0;
     }
@@ -171,20 +176,22 @@ http {
 
     include /etc/nginx/sites-enabled/*;
 }
-" > /etc/nginx/nginx.conf
-rm /etc/nginx/sites-enabled/*
 EOF
+
+RUN rm /etc/nginx/sites-enabled/*
 
 # Configure s6 nginx
 RUN <<EOF
 mkdir -p /etc/s6-overlay/s6-rc.d/nginx
-echo "longrun" > /etc/s6-overlay/s6-rc.d/nginx/type
-echo "#!/command/execlineb -P
-pipeline -w { sed --unbuffered \"s/^/nginx: /\" }
-fdmove -c 2 1
-/usr/sbin/nginx -g \"daemon off;\"
-" > /etc/s6-overlay/s6-rc.d/nginx/run
 touch /etc/s6-overlay/s6-rc.d/user/contents.d/nginx
+echo "longrun" > /etc/s6-overlay/s6-rc.d/nginx/type
+EOF
+
+COPY <<EOF /etc/s6-overlay/s6-rc.d/nginx/run
+#!/command/execlineb -P
+pipeline -w { sed --unbuffered "s/^/nginx: /" }
+fdmove -c 2 1
+/usr/sbin/nginx -g "daemon off;"
 EOF
 
 # Env variables
@@ -198,211 +205,246 @@ ARG GRAPHQL_PORT=10004
 ENV GRAPHQL_PORT=${GRAPHQL_PORT}
 ENV CARTESI_SNAPSHOT_DIR=${NODE_PATH}/snapshots
 
+################################################################################
 # Configure s6 create dir
 RUN <<EOF
 mkdir -p ${BASE_PATH}
 chown -R cartesi:cartesi ${BASE_PATH}
 mkdir -p /etc/s6-overlay/s6-rc.d/prepare-dirs
 echo "oneshot" > /etc/s6-overlay/s6-rc.d/prepare-dirs/type
-echo "#!/command/with-contenv sh
-mkdir -p \${SNAPSHOTS_APPS_PATH}
-mkdir -p \${NODE_PATH}/snapshots
-mkdir -p \${NODE_PATH}/data
-" > /etc/s6-overlay/s6-rc.d/prepare-dirs/run.sh
-chmod +x /etc/s6-overlay/s6-rc.d/prepare-dirs/run.sh
-echo "/etc/s6-overlay/s6-rc.d/prepare-dirs/run.sh" \
-> /etc/s6-overlay/s6-rc.d/prepare-dirs/up
 EOF
 
+COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/prepare-dirs/run.sh
+#!/command/with-contenv sh
+mkdir -p "${SNAPSHOTS_APPS_PATH}"
+mkdir -p "${NODE_PATH}"/snapshots
+mkdir -p "${NODE_PATH}"/data
+EOF
+
+COPY <<EOF /etc/s6-overlay/s6-rc.d/prepare-dirs/up
+/etc/s6-overlay/s6-rc.d/prepare-dirs/run.sh
+EOF
+
+################################################################################
 # Configure s6 migrate
 RUN <<EOF
 mkdir -p /etc/s6-overlay/s6-rc.d/migrate
-echo "oneshot" > /etc/s6-overlay/s6-rc.d/migrate/type
-echo "#!/command/with-contenv sh
-cartesi-rollups-cli db upgrade -p \${CARTESI_POSTGRES_ENDPOINT}
-" > /etc/s6-overlay/s6-rc.d/migrate/run.sh
-chmod +x /etc/s6-overlay/s6-rc.d/migrate/run.sh
-echo "/etc/s6-overlay/s6-rc.d/migrate/run.sh" \
-> /etc/s6-overlay/s6-rc.d/migrate/up
 touch /etc/s6-overlay/s6-rc.d/user/contents.d/migrate
+echo "oneshot" > /etc/s6-overlay/s6-rc.d/migrate/type
 EOF
 
+COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/migrate/run.sh
+#!/command/with-contenv sh
+cartesi-rollups-cli db upgrade -p ${CARTESI_POSTGRES_ENDPOINT}
+EOF
+
+COPY <<EOF /etc/s6-overlay/s6-rc.d/migrate/up
+/etc/s6-overlay/s6-rc.d/migrate/run.sh
+EOF
+
+################################################################################
 # Configure s6 create db
 RUN <<EOF
 mkdir -p /etc/s6-overlay/s6-rc.d/createhlgdb/dependencies.d
 touch /etc/s6-overlay/s6-rc.d/createhlgdb/dependencies.d/migrate
-echo "oneshot" > /etc/s6-overlay/s6-rc.d/createhlgdb/type
-echo "#!/command/with-contenv sh
-PGPASSWORD=\${POSTGRES_PASSWORD} psql -U \${POSTGRES_USER} -h \${POSTGRES_HOST} \
-    -c \"create database \${GRAPHQL_DB};\" || echo \"HLGraphql database alredy created\"
-" > /etc/s6-overlay/s6-rc.d/createhlgdb/run.sh
-chmod +x /etc/s6-overlay/s6-rc.d/createhlgdb/run.sh
-echo "/etc/s6-overlay/s6-rc.d/createhlgdb/run.sh" \
-> /etc/s6-overlay/s6-rc.d/createhlgdb/up
 touch /etc/s6-overlay/s6-rc.d/user/contents.d/createhlgdb
+echo "oneshot"/etc/s6-overlay/s6-rc.d/createhlgdb/type
 EOF
 
+COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/createhlgdb/run.sh
+#!/command/with-contenv sh
+PGPASSWORD=${POSTGRES_PASSWORD} psql -U ${POSTGRES_USER} -h ${POSTGRES_HOST} \
+    -c "create database ${GRAPHQL_DB};" || echo "HLGraphql database alredy created"
+EOF
+
+COPY <<EOF /etc/s6-overlay/s6-rc.d/createhlgdb/up
+/etc/s6-overlay/s6-rc.d/createhlgdb/run.sh
+EOF
+
+################################################################################
 # Configure s6 reader
 RUN <<EOF
 mkdir -p /etc/s6-overlay/s6-rc.d/reader/dependencies.d
-touch /etc/s6-overlay/s6-rc.d/reader/dependencies.d/prepare-dirs \
-    /etc/s6-overlay/s6-rc.d/reader/dependencies.d/migrate
-echo "longrun" > /etc/s6-overlay/s6-rc.d/reader/type
-echo "#!/command/with-contenv sh
-READER_CMD=cartesi-rollups-evm-reader
-if [ \${MAIN_SEQUENCER} = espresso ]; then
-    READER_CMD=cartesi-rollups-espresso-reader
-fi
-\${READER_CMD}
-" > /etc/s6-overlay/s6-rc.d/reader/start.sh
-echo "#!/command/execlineb -P
-with-contenv
-pipeline -w { sed --unbuffered \"s/^/reader: /\" }
-fdmove -c 2 1
-/bin/sh /etc/s6-overlay/s6-rc.d/reader/start.sh
-" > /etc/s6-overlay/s6-rc.d/reader/run
+touch /etc/s6-overlay/s6-rc.d/reader/dependencies.d/{prepare-dirs, migrate}
 touch /etc/s6-overlay/s6-rc.d/user/contents.d/reader
+echo "longrun" > /etc/s6-overlay/s6-rc.d/reader/type
 EOF
 
+COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/reader/start.sh
+#!/command/with-contenv sh
+READER_CMD=cartesi-rollups-evm-reader
+if [ ${MAIN_SEQUENCER} = espresso ]; then
+    READER_CMD=cartesi-rollups-espresso-reader
+fi
+${READER_CMD}
+EOF
+
+COPY <<EOF /etc/s6-overlay/s6-rc.d/reader/run
+#!/command/execlineb -P
+with-contenv
+pipeline -w { sed --unbuffered "s/^/reader: /" }
+fdmove -c 2 1
+/bin/sh /etc/s6-overlay/s6-rc.d/reader/start.sh
+EOF
+
+################################################################################
 # Configure s6 advancer
 RUN <<EOF
 mkdir -p /etc/s6-overlay/s6-rc.d/advancer/dependencies.d
-touch /etc/s6-overlay/s6-rc.d/advancer/dependencies.d/prepare-dirs \
-    /etc/s6-overlay/s6-rc.d/advancer/dependencies.d/migrate
-echo "longrun" > /etc/s6-overlay/s6-rc.d/advancer/type
-echo "#!/command/with-contenv sh
-cartesi-rollups-advancer
-" > /etc/s6-overlay/s6-rc.d/advancer/start.sh
-echo "#!/command/execlineb -P
-with-contenv
-pipeline -w { sed --unbuffered \"s/^/advancer: /\" }
-fdmove -c 2 1
-/bin/sh /etc/s6-overlay/s6-rc.d/advancer/start.sh
-" > /etc/s6-overlay/s6-rc.d/advancer/run
+touch /etc/s6-overlay/s6-rc.d/advancer/dependencies.d/{prepare-dirs, migrate}
 touch /etc/s6-overlay/s6-rc.d/user/contents.d/advancer
+echo "longrun" > /etc/s6-overlay/s6-rc.d/advancer/type
 EOF
 
+COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/advancer/start.sh
+#!/command/with-contenv sh
+cartesi-rollups-advancer
+EOF
+
+COPY <<EOF /etc/s6-overlay/s6-rc.d/advancer/run
+#!/command/execlineb -P
+with-contenv
+pipeline -w { sed --unbuffered "s/^/advancer: /" }
+fdmove -c 2 1
+/bin/sh /etc/s6-overlay/s6-rc.d/advancer/start.sh
+EOF
+
+################################################################################
 # Configure s6 validator
 RUN <<EOF
 mkdir -p /etc/s6-overlay/s6-rc.d/validator/dependencies.d
-touch /etc/s6-overlay/s6-rc.d/validator/dependencies.d/prepare-dirs \
-    /etc/s6-overlay/s6-rc.d/validator/dependencies.d/migrate
-echo "longrun" > /etc/s6-overlay/s6-rc.d/validator/type
-echo "#!/command/with-contenv sh
-cartesi-rollups-validator
-" > /etc/s6-overlay/s6-rc.d/validator/start.sh
-echo "#!/command/execlineb -P
-with-contenv
-pipeline -w { sed --unbuffered \"s/^/validator: /\" }
-fdmove -c 2 1
-/bin/sh /etc/s6-overlay/s6-rc.d/validator/start.sh
-" > /etc/s6-overlay/s6-rc.d/validator/run
+touch /etc/s6-overlay/s6-rc.d/validator/dependencies.d/{prepare-dirs, migrate}
 touch /etc/s6-overlay/s6-rc.d/user/contents.d/validator
+echo "longrun" > /etc/s6-overlay/s6-rc.d/validator/type
 EOF
 
+COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/validator/start.sh
+#!/command/with-contenv sh
+cartesi-rollups-validator
+EOF
+
+COPY <<EOF /etc/s6-overlay/s6-rc.d/validator/run
+#!/command/execlineb -P
+with-contenv
+pipeline -w { sed --unbuffered "s/^/validator: /" }
+fdmove -c 2 1
+/bin/sh /etc/s6-overlay/s6-rc.d/validator/start.sh
+EOF
+
+################################################################################
 # Configure s6 claimer
 RUN <<EOF
 mkdir -p /etc/s6-overlay/s6-rc.d/claimer/dependencies.d
-touch /etc/s6-overlay/s6-rc.d/claimer/dependencies.d/prepare-dirs \
-    /etc/s6-overlay/s6-rc.d/claimer/dependencies.d/migrate
+touch /etc/s6-overlay/s6-rc.d/claimer/dependencies.d/{prepare-dirs, migrate}
 echo "longrun" > /etc/s6-overlay/s6-rc.d/claimer/type
-echo "#!/command/with-contenv sh
-cartesi-rollups-claimer
-" > /etc/s6-overlay/s6-rc.d/claimer/start.sh
-echo "#!/command/execlineb -P
-with-contenv
-pipeline -w { sed --unbuffered \"s/^/claimer: /\" }
-fdmove -c 2 1
-/bin/sh /etc/s6-overlay/s6-rc.d/claimer/start.sh
-" > /etc/s6-overlay/s6-rc.d/claimer/run
 EOF
 
+COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/claimer/start.sh
+#!/command/with-contenv sh
+cartesi-rollups-claimer
+EOF
+
+COPY <<EOF /etc/s6-overlay/s6-rc.d/claimer/run
+#!/command/execlineb -P
+with-contenv
+pipeline -w { sed --unbuffered "s/^/claimer: /" }
+fdmove -c 2 1
+/bin/sh /etc/s6-overlay/s6-rc.d/claimer/start.sh
+EOF
+
+################################################################################
 # Configure s6 stage 2 hook
-RUN <<EOF
-mkdir -p /etc/s6-overlay/scripts
-echo "#!/command/with-contenv bash
-if [[ \${CARTESI_FEATURE_CLAIMER_ENABLED} = false ]] || \
-        [[ \${CARTESI_FEATURE_CLAIMER_ENABLED} = f ]] || \
-        [[ \${CARTESI_FEATURE_CLAIMER_ENABLED} = no ]] || \
-        [[ \${CARTESI_FEATURE_CLAIMER_ENABLED} = n ]] || \
-        [[ \${CARTESI_FEATURE_CLAIMER_ENABLED} = 0 ]]; then
+RUN mkdir -p /etc/s6-overlay/scripts
+
+ENV S6_STAGE2_HOOK=/etc/s6-overlay/scripts/stage2-hook.sh
+COPY --chmod=755 <<EOF /etc/s6-overlay/scripts/stage2-hook.sh
+#!/command/with-contenv bash
+if [[ ${CARTESI_FEATURE_CLAIMER_ENABLED} = false ]] || \
+        [[ ${CARTESI_FEATURE_CLAIMER_ENABLED} = f ]] || \
+        [[ ${CARTESI_FEATURE_CLAIMER_ENABLED} = no ]] || \
+        [[ ${CARTESI_FEATURE_CLAIMER_ENABLED} = n ]] || \
+        [[ ${CARTESI_FEATURE_CLAIMER_ENABLED} = 0 ]]; then
     echo 'Claimer disabled'
 else
     echo 'Claimer enabled'
     touch /etc/s6-overlay/s6-rc.d/user/contents.d/claimer
 fi
-" > /etc/s6-overlay/scripts/stage2-hook.sh
-chmod +x /etc/s6-overlay/scripts/stage2-hook.sh
 EOF
 
-ENV S6_STAGE2_HOOK=/etc/s6-overlay/scripts/stage2-hook.sh
-
+################################################################################
 # Configure s6 hlgraphql
 RUN <<EOF
 mkdir -p /etc/s6-overlay/s6-rc.d/hlgraphql/dependencies.d
 touch /etc/s6-overlay/s6-rc.d/hlgraphql/dependencies.d/createhlgdb
+touch /etc/s6-overlay/s6-rc.d/user/contents.d/hlgraphql
 echo "longrun" > /etc/s6-overlay/s6-rc.d/hlgraphql/type
-echo "#!/command/with-contenv sh
-POSTGRES_DB=\${GRAPHQL_DB} cartesi-rollups-hl-graphql \
+EOF
+
+COPY --chmod=755 <<EOF /etc/s6-overlay/s6-rc.d/hlgraphql/start.sh
+#!/command/with-contenv sh
+POSTGRES_DB=${GRAPHQL_DB} cartesi-rollups-hl-graphql \
     --disable-devnet \
     --disable-advance \
     --disable-inspect \
-    --http-port=\${GRAPHQL_PORT} \
+    --http-port=${GRAPHQL_PORT} \
     --raw-enabled \
     --high-level-graphql \
     --graphile-disable-sync \
     --db-implementation=postgres \
-    --db-raw-url=\${CARTESI_POSTGRES_ENDPOINT}
-" > /etc/s6-overlay/s6-rc.d/hlgraphql/start.sh
-echo "#!/command/execlineb -P
+    --db-raw-url=${CARTESI_POSTGRES_ENDPOINT}
+EOF
+
+COPY <<EOF /etc/s6-overlay/s6-rc.d/hlgraphql/run
+#!/command/execlineb -P
 with-contenv
-pipeline -w { sed --unbuffered \"s/^/hlgraphql: /\" }
+pipeline -w { sed --unbuffered "s/^/hlgraphql: /" }
 fdmove -c 2 1
 /bin/sh /etc/s6-overlay/s6-rc.d/hlgraphql/start.sh
-" > /etc/s6-overlay/s6-rc.d/hlgraphql/run
-touch /etc/s6-overlay/s6-rc.d/user/contents.d/hlgraphql
 EOF
 
 # deploy script
 RUN <<EOF
 mkdir -p /mnt/snapshots
 chown -R cartesi:cartesi /mnt
-echo "#!/bin/bash
-if [ ! -z \${OWNER} ]; then
-    owner_args=\"-o \${OWNER} -O \${OWNER}\"
+EOF
+
+COPY --chmod=755 <<EOF /deploy.sh
+#!/bin/bash
+if [ ! -z ${OWNER} ]; then
+    owner_args="-o ${OWNER} -O ${OWNER}"
 fi
-if [ ! -z \${AUTHORITY_ADDRESS} ]; then
-    authority_arg=\"-i \${AUTHORITY_ADDRESS}\"
+if [ ! -z ${AUTHORITY_ADDRESS} ]; then
+    authority_arg="-i ${AUTHORITY_ADDRESS}"
 fi
-if [ ! -z \${EPOCH_LENGTH} ]; then
-    epoch_arg=\"-e \${EPOCH_LENGTH}\"
+if [ ! -z ${EPOCH_LENGTH} ]; then
+    epoch_arg="-e ${EPOCH_LENGTH}"
 fi
-if [ ! -z \${SALT} ]; then
-    salt_arg=\"--salt \${SALT}\"
+if [ ! -z ${SALT} ]; then
+    salt_arg="--salt ${SALT}"
 fi
 cartesi-rollups-cli app deploy \
-    -t \$1 \
-    --private-key \${CARTESI_AUTH_PRIVATE_KEY} \
-    --rpc-url \${CARTESI_BLOCKCHAIN_HTTP_ENDPOINT} \
-    -p \${CARTESI_POSTGRES_ENDPOINT} \
-    \${owner_args} \
-    \${authority_arg} \
-    \${epoch_arg} \
-    \${salt_arg} \
-    \${EXTRA_ARGS} \
+    -t $1 \
+    --private-key ${CARTESI_AUTH_PRIVATE_KEY} \
+    --rpc-url ${CARTESI_BLOCKCHAIN_HTTP_ENDPOINT} \
+    -p ${CARTESI_POSTGRES_ENDPOINT} \
+    ${owner_args} \
+    ${authority_arg} \
+    ${epoch_arg} \
+    ${salt_arg} \
+    ${EXTRA_ARGS} \
     || echo 'Not deployed'
-" > /deploy.sh
-chmod +x /deploy.sh
-echo "#!/bin/bash
+EOF
+
+
+COPY --chmod=755 <<EOF /register.sh
+#!/bin/bash
 cartesi-rollups-cli app register \
-    -t \$1 \
-    -p \${CARTESI_POSTGRES_ENDPOINT} \
-    -a \${APPLICATION_ADDRESS} \
-    -i \${AUTHORITY_ADDRESS} \
-    \${EXTRA_ARGS} \
+    -t $1 \
+    -p ${CARTESI_POSTGRES_ENDPOINT} \
+    -a ${APPLICATION_ADDRESS} \
+    -i ${AUTHORITY_ADDRESS} \
+    ${EXTRA_ARGS} \
     || echo 'Not deployed'
-" > /register.sh
-chmod +x /register.sh
 EOF
 
 # =============================================================================
@@ -415,8 +457,7 @@ FROM base-rollups-node-we AS rollups-node-we-cloud
 RUN touch /etc/s6-overlay/s6-rc.d/user/contents.d/telegraf
 
 # Configure nginx server with cache
-RUN <<EOF
-echo "
+COPY --chmod=755 <<EOF /etc/nginx/sites-available/cloud.conf
 server {
     listen       80;
     listen  [::]:80;
@@ -453,20 +494,20 @@ server {
         root   /usr/share/nginx/html;
     }
 }
-" > /etc/nginx/sites-available/cloud.conf
-ln -sr /etc/nginx/sites-available/cloud.conf /etc/nginx/sites-enabled/cloud.conf
 EOF
 
+RUN ln -sr /etc/nginx/sites-available/cloud.conf /etc/nginx/sites-enabled/cloud.conf
+
 # Create init wrapper
-RUN <<EOF
-echo '#!/bin/sh
+COPY --chmod=755 <<EOF /init-wrapper
+#!/bin/sh
 # run /init with PID 1, creating a new PID namespace if necessary
 if [ "$$" -eq 1 ]; then
     # we already have PID 1
     exec /init "$@"
 else
     # create a new PID namespace
-    exec unshare --pid sh -c '"'"'
+    exec unshare --pid sh -c '
         # set up /proc and start the real init in the background
         unshare --mount-proc /init "$@" &
         child="$!"
@@ -476,10 +517,8 @@ else
         # wait until the real init exits
         # ("wait" returns early on signals; "kill -0" checks if the process exists)
         until wait "$child" || ! kill -0 "$child" 2>/dev/null; do :; done
-    '"'"' sh "$@"
+    ' sh "$@"
 fi
-' > /init-wrapper
-chmod +x /init-wrapper
 EOF
 
 CMD ["/init-wrapper"]
@@ -490,8 +529,7 @@ FROM base-rollups-node-we AS rollups-node-we
 RUN chown -R cartesi:cartesi /run
 
 # Configure nginx server with cache
-RUN <<EOF
-echo "
+COPY --chmod=755 <<EOF /etc/nginx/sites-available/node.conf
 server {
     listen       80;
     listen  [::]:80;
@@ -517,13 +555,12 @@ server {
         root   /usr/share/nginx/html;
     }
 }
-" > /etc/nginx/sites-available/node.conf
-ln -sr /etc/nginx/sites-available/node.conf /etc/nginx/sites-enabled/node.conf
 EOF
+
+RUN ln -sr /etc/nginx/sites-available/node.conf /etc/nginx/sites-enabled/node.conf
 
 # Set user to low-privilege.
 USER cartesi
 
 # Set the Go supervisor as the command.
 CMD [ "/init" ]
-


### PR DESCRIPTION
This pull request includes several changes to the `backend-node.dockerfile` to improve configuration and script management. The most important changes involve replacing inline script definitions with `COPY` commands to include external script files, ensuring better readability and maintainability.

Improvements to configuration and script management:

* Replaced inline script definitions with `COPY` commands for various configurations, including Telegraf, nginx, and s6 overlay scripts. This change ensures that scripts are maintained as separate files, improving readability and maintainability. [[1]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615R82-R85) [[2]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L111-R141) [[3]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L151-R159) [[4]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L165-R170) [[5]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L174-R194) [[6]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615R208-L405) [[7]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L418-R454) [[8]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L456-R504) [[9]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L479-L482) [[10]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L493-R526)

* Updated the nginx configuration to use `COPY` commands for the `nginx.conf` and site-specific configurations, ensuring that these configurations are stored in separate files. [[1]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L151-R159) [[2]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L165-R170) [[3]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L174-R194) [[4]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L418-R454) [[5]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L456-R504) [[6]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L493-R526)

* Changed the method of setting up s6 services by using `COPY` commands to include external script files for service configurations, such as `run.sh` and `up` scripts. This change helps maintain the scripts as separate entities and simplifies the Dockerfile. [[1]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615R208-L405) [[2]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L418-R454) [[3]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L456-R504) [[4]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L479-L482) [[5]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L493-R526)

* Added proper permissions to the copied script files using `--chmod=755` with the `COPY` command to ensure they are executable. This change ensures that the scripts have the correct permissions when they are copied into the Docker image. [[1]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615R208-L405) [[2]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L418-R454) [[3]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L456-R504) [[4]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L479-L482) [[5]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L493-R526)

* Improved the readability of the Dockerfile by adding section separators and comments to clearly delineate different configuration sections, making it easier to understand and maintain. [[1]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615R82-R85) [[2]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L111-R141) [[3]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L151-R159) [[4]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L165-R170) [[5]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L174-R194) [[6]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615R208-L405) [[7]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L418-R454) [[8]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L456-R504) [[9]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L479-L482) [[10]](diffhunk://#diff-5effcdf67aa7981010866c985f74f40cc27c554af0d63415de56ebbe90cb7615L493-R526)